### PR TITLE
Clear error stack after validation failure

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -10,7 +10,7 @@ Description:
     systems and stable. You may also be interested in the @tls@ package,
     <http://hackage.haskell.org/package/tls>, which is a pure Haskell
     implementation of SSL.
-Version:       0.11.7.6
+Version:       0.11.7.7
 License:       PublicDomain
 License-File:  COPYING
 Author:        Adam Langley, Mikhail Vorozhtsov, PHO, Taru Karttunen

--- a/OpenSSL/Utils.hs
+++ b/OpenSSL/Utils.hs
@@ -4,11 +4,13 @@ module OpenSSL.Utils
     , failIf
     , failIf_
     , raiseOpenSSLError
+    , clearErrorStack
     , toHex
     , fromHex
     , peekCStringCLen
     )
     where
+import Control.Monad
 import Foreign.C.String
 import Foreign.C.Types
 import Foreign.Ptr
@@ -40,6 +42,12 @@ failIf_ f a
 
 raiseOpenSSLError :: IO a
 raiseOpenSSLError = getError >>= errorString >>= fail
+
+
+clearErrorStack :: IO ()
+clearErrorStack = do
+  e <- getError
+  when (e /= 0) clearErrorStack
 
 -- | Convert an integer to a hex string
 toHex :: (Num i, Bits i) => i -> String

--- a/OpenSSL/X509.hsc
+++ b/OpenSSL/X509.hsc
@@ -274,7 +274,9 @@ verifyX509 x509 key
     where
       interpret :: CInt -> IO VerifyStatus
       interpret 1 = return VerifySuccess
-      interpret 0 = return VerifyFailure
+      interpret 0 = do
+        clearErrorStack
+        return VerifyFailure
       interpret _ = raiseOpenSSLError
 
 -- |@'printX509' cert@ translates a certificate into human-readable


### PR DESCRIPTION
When `x509_verify` fails validating a certificate, it leaves a number of errors on the stack. These need to be cleared before returning, otherwise the global library state is contaminated and that can affect subsequent uses of the library.