### PR TITLE
CI: Fix OSX, remove windows, add recent GHCs

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,10 +15,39 @@ jobs:
         # number instances is a good way to trigger flaky build failures
         n: [1]
 
-        ghc: ["8.10.7"]
+        ghc:
+        - "8.0.2"
+        - "8.2.2"
+        - "8.4.4"
+        - "8.6.5"
+        - "8.8.4"
+        - "8.10.7"
+        - "9.0.2"
+        - "9.2.8"
+        - "9.4.8"
+        - "9.6.6"
+        - "9.8.2"
+        - "9.10.1"
         # FIXME: Add windows-latest back to CI once it is passing.
         os: [ubuntu-latest, macos-latest]
 
+        # Action fails to install GHC < 8.10 on OSX with a generic error
+        # messsage:
+        #
+        #   Error: All install methods for ghc 8.0.2 failed
+        #
+        # On the other hand, 8.10 and 9.0 fail due to LLVM:
+        #
+        #   Warning: Couldn't figure out LLVM version!
+        #            Make sure you have installed LLVM between [9 and 13)
+        exclude:
+          - {ghc: "8.0.2", os: "macos-latest"}
+          - {ghc: "8.2.2", os: "macos-latest"}
+          - {ghc: "8.4.4", os: "macos-latest"}
+          - {ghc: "8.6.5", os: "macos-latest"}
+          - {ghc: "8.8.4", os: "macos-latest"}
+          - {ghc: "8.10.7", os: "macos-latest"}
+          - {ghc: "9.0.2", os: "macos-latest"}
     env:
       # OpenSSL is installed in a non-standard location in MacOS. See
       # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-latest-Readme.md

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,8 @@ jobs:
         n: [1]
 
         ghc: ["8.10.7"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # FIXME: Add windows-latest back to CI once it is passing.
+        os: [ubuntu-latest, macos-latest]
 
     env:
       # OpenSSL is installed in a non-standard location in MacOS. See

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,6 +28,10 @@ jobs:
       LD_LIBRARY_PATH: ${{ (matrix.os != 'windows-latest' && '/usr/local/lib') || '' }}
 
     steps:
+    - uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+
     - name: "WIN: Install System Dependencies via pacman (msys2)"
       if: runner.os == 'Windows'
       run: |
@@ -46,7 +50,8 @@ jobs:
     # this seems to break something. It _must_ come after the pacman setup
     # above. It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and
     # as such we'd need pacman.exe instead.
-    - name: Setup Haskell
+    - name: "WIN: Setup Haskell"
+      if: runner.os == 'Windows'
       run: |
         # Use GHCUP to manage ghc/cabal
         ghcup install ghc --set ${{ matrix.ghc }}

--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -21,7 +21,18 @@ Bug-Reports:   https://github.com/haskell-cryptography/HsOpenSSL/issues
 Category:      Cryptography
 Cabal-Version: 1.12
 Tested-With:
-    GHC==8.8.1, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3
+    GHC ==8.0.2
+     || ==8.2.2
+     || ==8.4.4
+     || ==8.6.5
+     || ==8.8.4
+     || ==8.10.7
+     || ==9.0.2
+     || ==9.2.8
+     || ==9.4.8
+     || ==9.6.6
+     || ==9.8.1
+     || ==9.10.1
 Build-Type:    Custom
 Extra-Source-Files:
     AUTHORS


### PR DESCRIPTION
Addresses #90 (partially).

This PR does 3 things wrt CI:

1. Comments out windows.
2. Fixes OSX.
3. Adds recent GHCs.

In a little more detail:

1. I attempted to fix the Windows job myself, but it's tricky. The current error is:

    ```
    ghcup.exe: pacman: createProcess: does not exist (No such file or directory)
    ```
    
    That is, `ghcup` cannot find `pacman`. When I looked myself (i.e. `tree C:\msys64`), I couldn't find it either! Not sure if something changed here, or what. The only way I was able to reliably find `pacman` is to use the [dedicated action](https://github.com/msys2/setup-msys2) -- as opposed to relying on the image's default setup -- and running in the `msys` shell (yaml: `shell: msys2 {0}`). But that messes up other paths. Frankly, I think this requires someone familiar with `msys2`/`windows`, which is sadly not me.
    
2. The OSX error, on the other hand, is the relatively simple:

    ```
    ghcup: command not found
    ```
    
    The image is _supposed_ to include `ghcup` (source [here](https://github.com/actions/runner-images/blob/dd3eec73740f763c8465e9dcba5a5c197614a6a4/images/macos/scripts/build/install-haskell.sh)), but from scanning the issues, it seems this is somewhat flaky. Switching to [haskell-actions/setup](https://github.com/haskell-actions/setup) fixes the error (somehow). As the setup action is well-maintained and reliable IME (and semi-official?), I think this is a reasonable switch regardless.
    
3. Added recent GHCs and updated the `tested-with` section in the cabal file. This is pretty straightforward, though I do have to exclude `GHC < 9.2 && osx`, due to problems with the OSX images and older GHCs.

This PR does not fix windows, nor does it address the old versions of `openssl`. I'm open to considering them too, but would need more guidance on windows, at least.